### PR TITLE
feat: 添加支付宝语音播报功能

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ import logger from './src/logger';
 import RandomSeed from 'random-seed';
 import sendSetu from './src/plugin/setu';
 import Akhr from './src/plugin/akhr';
+import alipayHandler from './src/plugin/alipayVoice';
 import _ from 'lodash';
 import minimist from 'minimist';
 import { rmdHandler } from './src/plugin/reminder';
@@ -187,6 +188,11 @@ async function commonHandle(e, context) {
   // setu
   if (config.setu.enable) {
     if (sendSetu(context)) return true;
+  }
+
+  // 支付宝语音播报
+  if (config.alipay.enable) {
+    if (alipayHandler(context)) return true;
   }
 
   //  反哔哩哔哩小程序

--- a/src/CQcode.js
+++ b/src/CQcode.js
@@ -55,7 +55,7 @@ class CQCode {
     const reg = /\[CQ:([^,[\]]+)((?:,[^,=[\]]+=[^,[\]]*)*)\]/g;
     const result = [];
     // eslint-disable-next-line space-in-parens
-    for (let match; (match = reg.exec(str)); ) {
+    for (let match; (match = reg.exec(str));) {
       const [, type, dataStr] = match;
       const data = _.transform(
         _.filter(dataStr.split(',')),
@@ -187,6 +187,20 @@ class CQCode {
    */
   static reply(id) {
     return new CQCode('reply', { id }).toString();
+  }
+
+  /**
+   * CQ码 语音
+   * @param {string} file 语音文件名 活 语音地址
+   * @param {boolean} [magic=0] 是否变声
+   * @param {boolean} [cache=1] 是否缓存
+   * @param {boolean} [proxy=1] 是否代理
+   * @example
+   * CQ.redbag("http://baidu.com/1.mp3");
+   * CQ.redbag("http://baidu.com/1.mp3",1);
+  */
+  static record(file, proxy = 1, cache = 1, magic = 0) {
+    return new CQCode('record', { file, proxy, cache, magic }).toString();
   }
 }
 

--- a/src/plugin/alipayVoice.js
+++ b/src/plugin/alipayVoice.js
@@ -1,0 +1,37 @@
+import CQ from '../CQcode';
+
+//  符合范围
+const isRange = (num) => {
+  const n = parseFloat(num);
+  const range = [0.01, 99999999.99];
+  return n >= range[0] && n <= range[1];
+};
+
+const getURL = (num) => {
+  // 判断num是否为数字或者小数
+  const REG_NUM = /^\d+(\.\d+)?$/;
+  if (REG_NUM.test(num) && isRange(num)) {
+    return `https://api.uutool.cn/audio/payment/alipay/${num}.mp3`;
+    // 备用地址
+    // return `https://mm.cqu.cc/share/zhifubaodaozhang/mp3/${num}.mp3`;
+  }
+  return '';
+};
+
+const doReply = (context) => {
+  // 获取金额数字
+  const num = context.message.replace(/^\/alipay/, '').trim();
+  const url = getURL(num);
+  if (url) {
+    // 回复语音
+    return global.replyMsg(context, CQ.record(url));
+  }
+  return global.replyMsg(context, '请输入正确的金额数字,取值范围0.01~999999999999.99');
+};
+
+export default function alipayVoiceHandler(context) {
+  if (/^\/alipay/.test(context.message)) {
+    doReply(context);
+    return true;
+  } else return false;
+}

--- a/src/plugin/alipayVoice.js
+++ b/src/plugin/alipayVoice.js
@@ -26,7 +26,7 @@ const doReply = (context) => {
     // 回复语音
     return global.replyMsg(context, CQ.record(url));
   }
-  return global.replyMsg(context, '请输入正确的金额数字,取值范围0.01~999999999999.99');
+  return global.replyMsg(context, '请输入正确的金额数字,取值范围0.01~99999999.99');
 };
 
 export default function alipayVoiceHandler(context) {


### PR DESCRIPTION
# 🚀 说明
- 添加支付宝语音播报功能

发送 `/alipay 100` 命令，bot 将回复`支付宝到账100元`语音。

# ⚠️ 注意

`cq-gohttp` 运行环境需要安装 `ffmpeg` 运行库。