### PR TITLE
修复了一下在分享了之后的小程序时可能遇到的bug

### DIFF
--- a/src/plugin/bilibili/index.mjs
+++ b/src/plugin/bilibili/index.mjs
@@ -17,7 +17,7 @@ const recallWatch = new NodeCache({ stdTTL: 3 * 60 });
 
 const getIdFromNormalLink = link => {
   if (typeof link !== 'string') return null;
-  const searchVideo = /bilibili\.com\/video\/(?:av(\d+)|(bv[\da-z]+))/i.exec(link) || {};
+  const searchVideo = /bilibili\.com\/video\/(?:av(\d+)|(bv[\da-z]+))/i.exec(link) || /bilibili\.com\\\/video\\\/(?:av(\d+)|(bv[\da-z]+))/i.exec(link) || {};
   const searchDynamic = /t\.bilibili\.com\/(\d+)/i.exec(link) || /m\.bilibili\.com\/dynamic\/(\d+)/i.exec(link) || {};
   const searchArticle = /bilibili\.com\/read\/(?:cv|mobile\/)(\d+)/i.exec(link) || {};
   const searchLiveRoom = /live\.bilibili\.com\/(\d+)/i.exec(link) || {};


### PR DESCRIPTION
~~~
&#91;&#91;QQ小程序&#93;哔哩哔哩&#93;请使用最新版本手机QQ查看[CQ:json,data={"app":"com.tencent.miniapp_01"&#44;"desc":"哔哩哔哩"&#44;"view":"view_8C8E89B49BE609866298ADDFF2DBABA4"&#44;"ver":"1.0.0.19"&#44;"prompt":"&#91;QQ小程序&#93;哔哩哔哩"&#44;"meta":{"detail_1":{"appType":0&#44;"appid":"1109937557"&#44;"desc":"&#91;Minecraft-AE2&#93; 1.19.2 赛特斯石英水晶获取方法更新"&#44;"gamePoints":""&#44;"gamePointsUrl":""&#44;"host":{"nick":"幻空"&#44;"uin":2564076459}&#44;"icon":"https:\/\/open.gtimg.cn\/open\/app_icon\/00\/95\/17\/76\/100951776_100_m.png?t=1670465795"&#44;"preview":"pubminishare-30161.picsz.qpic.cn\/3871d4db-47de-49ad-a80a-6861aec12ef7"&#44;"qqdocurl":"https:\/\/www.bilibili.com\/video\/av902992871?share_session_id=f85ea9b8-b9fd-4372-b439-a30bcd4ffdfd&amp;share_medium=android&amp;share_source=qq&amp;bbid=XU470FF4A23CE43667C73F2267209A7F29916&amp;ts=1670893673399"&#44;"scene":1036&#44;"shareTemplateData":{}&#44;"shareTemplateId":"8C8E89B49BE609866298ADDFF2DBABA4"&#44;"showLittleTail":""&#44;"title":"哔哩哔哩"&#44;"url":"m.q.qq.com\/a\/s\/ccf70958ca193517089c1fd88adcd370"}}&#44;"config":{"autoSize":0&#44;"ctime":1670893681&#44;"forward":1&#44;"height":0&#44;"token":"f4378698d14667bc0641973aee71eff6"&#44;"type":"normal"&#44;"width":0}}]
~~~
有的时候分享之后的小程序会变成这样，把正则改一下就可以恢复正常了